### PR TITLE
Fix botExp over 500 if user feed over 1000 at a time

### DIFF
--- a/9armbot/9armbot.js
+++ b/9armbot/9armbot.js
@@ -58,9 +58,11 @@ function feedBot(channel, user, amount) {
     if (deductCoins(user.username, amount)) {
         botExp += amount;
         if (botExp >= 500) { // level up
-            botExp -= 500;
-            baseTimeoutSeconds+=10;
-            botLevel++;
+            // prevent feed over 1000 per time
+            levelUp = Math.floor(botExp / 500);
+            botExp = botExp % 500;
+            baseTimeoutSeconds+=10 * levelUp;
+            botLevel += levelUp;
             client.say(channel, `LEVEL UP!! ->${botLevel}`);
         }
     }


### PR DESCRIPTION
Use floor divide to calc how many level for bot to level up. And use mod to clear exp.