### PR TITLE
Fix 0 coins returning user not found in Discord

### DIFF
--- a/9armbot/discord_bot.js
+++ b/9armbot/discord_bot.js
@@ -95,7 +95,7 @@ class discordBot {
             if (group && group[1]) {
                 group[1] = group[1].toLowerCase();
                 let coin = this.getCoins(group[1])
-                if (coin) {
+                if (coin != null) {
                     this.showCoinsDialog(msg.channel.id, group[1], coin)
                 } else {
                     this.sendChat(msg.channel.id, `ไม่พบ username <${group[1]}> โปรดใส่ Twitch username..`)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/248741/115991445-a131db80-a5f2-11eb-9227-f8584ce5f265.png)

The reason of this bug is `0` is falsey

```javascript
> !!0
false
```