### PR TITLE
Discord whitelist channels for coin command

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,4 @@ DATABASE_URL="file:./dev.db"
 BOTV2_DISCORD_OAUTH_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 BOTV2_TWITCH_OAUTH_TOKEN="oauth:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 SILENT_BOT_MODE="0"
+DISCORD_WHITELIST_CHANNELS="9armbot" # Separate channel names with comma (,)

--- a/9armbot-2.0/services/discord.ts
+++ b/9armbot-2.0/services/discord.ts
@@ -61,6 +61,24 @@ export async function discordService() {
         break
 
       case '!coin':
+        if (`${process.env.DISCORD_WHITELIST_CHANNELS}`.length) {
+          const whitelistChannels =
+            process.env.DISCORD_WHITELIST_CHANNELS!.split(',')
+
+          if (
+            msg.channel.type == 'text' &&
+            !whitelistChannels.includes(msg.channel.name!)
+          ) {
+            await botSay(
+              msg.channel,
+              `ไปถามในห้อง ${whitelistChannels
+                .map((c) => `#${c}`)
+                .join(', ')} หรือ dm นะจ๊ะ`,
+            )
+            return
+          }
+        }
+
         const group = msg.content.match(/!coin\s+([a-zA-Z0-9_]*)/)
         if (group && group[1]) {
           const username = group[1].toLowerCase()


### PR DESCRIPTION
- กำหนด env `DISCORD_WHITELIST_CHANNELS` ด้วยชื่อ discord channel ที่อนุญาตให้ใช้คำสั่ง `!coin` (ถ้ามีหลาย channel ให้คั่นด้วย `,`) ถ้าไม่ได้กำหนดจะใช้ได้ทุก channel

![image](https://user-images.githubusercontent.com/248741/124135927-78c0d480-daae-11eb-8a4a-1e59e833acb6.png)
